### PR TITLE
Change how enemies move in block

### DIFF
--- a/configurations.py
+++ b/configurations.py
@@ -44,6 +44,7 @@ BULLET_SHOOTING_SOUND_PATH = join(PWD, MUSIC_DIRECTORY_NAME, "laser.wav")
 GAME_FONT = "freesansbold.ttf"
 
 # Other
+
 OFF_SCREEN = -1
 X_LOWER_BOUNDARY = 0
 Y_LOWER_BOUNDARY = 0

--- a/core.py
+++ b/core.py
@@ -42,16 +42,22 @@ def do_game_over(enemies, screen):
     show_game_over_text()
 
 
-def go_down_right(enemy):
+def go_down_right(enemies, screen):
 
-    enemy.x_cord_change = configurations.DEFAULT_ENEMY_SPEED
-    enemy.y_cord += enemy.y_cord_change
+    for enemy in enemies:
+        enemy.x_cord_change = configurations.DEFAULT_ENEMY_SPEED
+        enemy.y_cord += enemy.y_cord_change
+        enemy.blit(screen)
+        enemy.x_cord += enemy.x_cord_change
 
 
-def go_down_left(enemy):
+def go_down_left(enemies, screen):
 
-    enemy.x_cord_change = configurations.DEFAULT_ENEMY_SPEED * -1
-    enemy.y_cord += enemy.y_cord_change
+    for enemy in enemies:
+        enemy.x_cord_change = configurations.DEFAULT_ENEMY_SPEED * -1
+        enemy.y_cord += enemy.y_cord_change
+        enemy.blit(screen)
+        enemy.x_cord += enemy.x_cord_change
 
 
 def is_collision(x1, x2, y1, y2):
@@ -67,7 +73,7 @@ def destroy_enemy(bullet, enemy, enemies, score):
     explosion_sound = mixer.Sound(configurations.EXPLOSION_SOUND_PATH)
     explosion_sound.play()
     bullet.y_cord = configurations.OFF_SCREEN
-    Bullet.bullet_state = Bullet.BULLET_READY
+    Bullet.reset_bullet_state()
     score.add_points(configurations.POINTS_PER_KILL)
     enemies.remove(enemy)
 

--- a/main.py
+++ b/main.py
@@ -110,13 +110,16 @@ def main():
                 break
             if bullet_enemy_collision:
                 core.destroy_enemy(bullet, enemy, enemies, score)
+                continue
             elif (
                 enemy.x_cord + enemy.x_cord_change
                 < configurations.X_LOWER_BOUNDARY
             ):
-                core.go_down_right(enemy)
+                core.go_down_right(enemies, screen)
+                break
             elif enemy.x_cord + enemy.x_cord_change > X_UPPER_BOUNDARY_ENEMY:
-                core.go_down_left(enemy)
+                core.go_down_left(enemies, screen)
+                break
             enemy.blit(screen)
             enemy.x_cord += enemy.x_cord_change
 


### PR DESCRIPTION
### Summary

- Enemies will now move on both ends of the screen as a block.
- Fixed bug where destroying an enemy would require the user to
press the space-bar twice to fire again.